### PR TITLE
Reorganize landmark resource hub layout

### DIFF
--- a/landmark/index.md
+++ b/landmark/index.md
@@ -9,45 +9,97 @@ Welcome to the Landmark Papers collection — a curated set of high-impact surgi
 
 ---
 
-- [FOCUS](/landmark/focus)
-- [TRICC](/landmark/tricc)
-- [TRISS](/landmark/triss)
-- [CORTICUS](/landmark/corticus)
-- [PROPPR](/landmark/proppr)
-- [DCL](/landmark/dcl)
-- [TACS](/landmark/tacs)
-- [PATCH](/landmark/patch)
-- [TITRe2](/landmark/titre2)
-- [REACT-2](/landmark/react2)
-- [DROOL](/landmark/drool)
-- [STITCH](/landmark/stitch)
-- [TAVR](/landmark/tavr)
-- [NASCET](/landmark/nascet)
-- [COST](/landmark/cost)
-- [STOP-IT](/landmark/stopit)
-- [CROSS](/landmark/cross)
-- [ACOSOG-Z0011](/landmark/acosog-z0011)
-- [NSABP-B32](/landmark/nsabp-b32)
-- [FAME](/landmark/fame)
-- [SMART](/landmark/smart)
-- [STAMPEDE](/landmark/stampede)
-- [AAA EVAR](/landmark/aaa-evar)
-- [LUNG](/landmark/lung)
-- [APPENDIX IRRIGATE](/landmark/appendix-irrigate)
-- [CHEST TUBE SIZE](/landmark/chest-tube)
-- [FRACTURE: MESS](/landmark/mangled-extremity)
-- [IJ CATHETERIZATION](/landmark/ij-access)
-- [PLATYSMA CLOSURE](/landmark/platysma)
-- [PARATHYROID AUTOFLUORESCENCE](/landmark/parathyroid-af)
-- [PANCREATIC TRAUMA](/landmark/pancreatic-trauma)
-- [ESOPHAGEAL TRAUMA](/landmark/esophageal-trauma)
-- [COLITIS AND CRC](/landmark/colitis-crc)
-- [RETROPERITONEAL HEMOTHORAX](/landmark/hemothorax)
-- [HERNIA BIOLOGIC MESH](/landmark/hernia-mesh)
-- [NECROTIZING PANCREATITIS](/landmark/stepup-pancreatitis)
-- [BRAIN INJURY PEDIATRICS](/landmark/pecarn)
-- [FOLEY REMOVAL TIMING](/landmark/foley-timing)
-- [ILEUS RCTs](/landmark/ileus)
-- [STAB WOUND MANAGEMENT](/landmark/stab-wound)
-- [HPYLORI AFTER SURGERY](/landmark/hpylori-surgery)
-- [ULCERATIVE COLITIS SURGERY](/landmark/uc-surgery)
+## Landmark Papers
+
+Explore definitive trials and practice-changing studies, organized in an easy-to-scan grid for faster review.
+
+<table class="resource-grid">
+  <tbody>
+    <tr>
+      <td>[FOCUS](/landmark/focus)</td>
+      <td>[TRICC](/landmark/tricc)</td>
+      <td>[TRISS](/landmark/triss)</td>
+    </tr>
+    <tr>
+      <td>[CORTICUS](/landmark/corticus)</td>
+      <td>[PROPPR](/landmark/proppr)</td>
+      <td>[DCL](/landmark/dcl)</td>
+    </tr>
+    <tr>
+      <td>[TACS](/landmark/tacs)</td>
+      <td>[PATCH](/landmark/patch)</td>
+      <td>[TITRe2](/landmark/titre2)</td>
+    </tr>
+    <tr>
+      <td>[REACT-2](/landmark/react2)</td>
+      <td>[DROOL](/landmark/drool)</td>
+      <td>[STITCH](/landmark/stitch)</td>
+    </tr>
+    <tr>
+      <td>[TAVR](/landmark/tavr)</td>
+      <td>[NASCET](/landmark/nascet)</td>
+      <td>[COST](/landmark/cost)</td>
+    </tr>
+    <tr>
+      <td>[STOP-IT](/landmark/stopit)</td>
+      <td>[CROSS](/landmark/cross)</td>
+      <td>[ACOSOG-Z0011](/landmark/acosog-z0011)</td>
+    </tr>
+    <tr>
+      <td>[NSABP-B32](/landmark/nsabp-b32)</td>
+      <td>[FAME](/landmark/fame)</td>
+      <td>[SMART](/landmark/smart)</td>
+    </tr>
+    <tr>
+      <td>[STAMPEDE](/landmark/stampede)</td>
+      <td>[AAA EVAR](/landmark/aaa-evar)</td>
+      <td>[LUNG](/landmark/lung)</td>
+    </tr>
+    <tr>
+      <td>[APPENDIX IRRIGATE](/landmark/appendix-irrigate)</td>
+      <td>[CHEST TUBE SIZE](/landmark/chest-tube)</td>
+      <td>[FRACTURE: MESS](/landmark/mangled-extremity)</td>
+    </tr>
+    <tr>
+      <td>[IJ CATHETERIZATION](/landmark/ij-access)</td>
+      <td>[PLATYSMA CLOSURE](/landmark/platysma)</td>
+      <td>[PARATHYROID AUTOFLUORESCENCE](/landmark/parathyroid-af)</td>
+    </tr>
+    <tr>
+      <td>[PANCREATIC TRAUMA](/landmark/pancreatic-trauma)</td>
+      <td>[ESOPHAGEAL TRAUMA](/landmark/esophageal-trauma)</td>
+      <td>[COLITIS AND CRC](/landmark/colitis-crc)</td>
+    </tr>
+    <tr>
+      <td>[RETROPERITONEAL HEMOTHORAX](/landmark/hemothorax)</td>
+      <td>[HERNIA BIOLOGIC MESH](/landmark/hernia-mesh)</td>
+      <td>[NECROTIZING PANCREATITIS](/landmark/stepup-pancreatitis)</td>
+    </tr>
+    <tr>
+      <td>[BRAIN INJURY PEDIATRICS](/landmark/pecarn)</td>
+      <td>[FOLEY REMOVAL TIMING](/landmark/foley-timing)</td>
+      <td>[ILEUS RCTs](/landmark/ileus)</td>
+    </tr>
+    <tr>
+      <td>[STAB WOUND MANAGEMENT](/landmark/stab-wound)</td>
+      <td>[HPYLORI AFTER SURGERY](/landmark/hpylori-surgery)</td>
+      <td>[ULCERATIVE COLITIS SURGERY](/landmark/uc-surgery)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Topic Review
+
+Deep-dive into themes that bridge multiple trials, with concise summaries and must-read reviews.
+
+- [Perioperative Optimization (Coming Soon)](#)
+- [Oncology: Multimodal Strategies (Coming Soon)](#)
+- [Trauma Systems & Damage Control (Coming Soon)](#)
+
+## Case Prep
+
+Targeted bundles for oral boards and case conferences, pairing landmark data with key talking points.
+
+- [Emergency General Surgery Cases (Coming Soon)](#)
+- [Complex Oncologic Reconstructions (Coming Soon)](#)
+- [Vascular & Endovascular Pearls (Coming Soon)](#)


### PR DESCRIPTION
## Summary
- replace the long landmark paper list with a three-column grid for easier browsing
- add topic review and case prep sections to position the page as the central resource hub

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c25c08fc8326b93e56511b2e1194