### PR TITLE
Add Landmark study collections and layouts

### DIFF
--- a/_case_preps/whipple-case-prep.md
+++ b/_case_preps/whipple-case-prep.md
@@ -1,0 +1,55 @@
+---
+layout: case-prep
+title: "Pancreaticoduodenectomy (Whipple)"
+exam_focus: "OR Case Prep"
+difficulty: "Complex"
+attending_notes: "Dr. Alvarez prioritizes vascular control plans and post-op drain strategy."
+time_goal: "Night-before run-through"
+patient_profile: "68-year-old with pancreatic head adenocarcinoma, biliary stent in place."
+high_yield_pearls:
+  - "Confirm SMA and SMV involvement on cross-sectional imaging before committing to resection."
+  - "Review variant hepatic arterial anatomy, especially replaced right hepatic artery."
+  - "Discuss plan for pancreaticojejunostomy technique (duct-to-mucosa vs. dunk)."
+workflow_steps:
+  - "Pre-op briefing with anesthesia to coordinate central access and hemodynamic monitoring."
+  - "Confirm availability of cell saver and vascular instruments."
+  - "Explore abdomen, rule out metastasis, and mobilize hepatic flexure."
+  - "Control gastroduodenal artery early and test hepatic arterial flow before transection."
+  - "Kocherize duodenum and assess SMA/SMV involvement."
+  - "Divide pancreas at neck with frozen section and protect SMV/PV confluence."
+  - "Resect specimen with en bloc gallbladder and bile duct."
+  - "Perform pancreaticojejunostomy with stent placement as indicated."
+  - "Construct hepaticojejunostomy and antecolic gastrojejunostomy."
+  - "Place drains near PJ and HJ, confirm hemostasis, and plan ICU disposition."
+pimp_questions:
+  - question: "What are the key anatomic boundaries of the triangle of Whipple?"
+    answer: "Cystic duct superiorly, common hepatic duct medially, and common bile duct laterally."
+  - question: "How do you manage a soft pancreas with small duct intraoperatively?"
+    answer: "Use duct-to-mucosa anastomosis with internal stent and reinforce with external sutures or dunk technique depending on texture."
+  - question: "List the components of the Whipple reconstruction."
+    answer: "Pancreaticojejunostomy, hepaticojejunostomy, and gastrojejunostomy."
+anatomy_maps:
+  - title: "Arterial variants"
+    details: "Identify replaced hepatic and right gastric arteries to avoid ischemic complications."
+  - title: "Venous structures"
+    details: "SMV-PV confluence and tributaries (IPDV, gastrocolic trunk) demand protection during uncinate dissection."
+attending_specific_comments:
+  - "Outline rescue plan for portal vein reconstruction if tumor abuts SMV."
+  - "Communicate postoperative insulin and pancreatic enzyme replacement plan."
+preop_checklist:
+  - "ERAS labs reviewed and transfusion consent signed."
+  - "Octreotide ordered per attending preference."
+  - "ICU bed reserved for postoperative monitoring."
+reading_list:
+  - "NCCN Guidelines for Pancreatic Adenocarcinoma"
+  - "Johns Hopkins operative atlas chapter on Whipple"
+---
+
+## Mental Rehearsal Notes
+
+Capture your own rehearsal script here—focus on vascular steps, reconstruction order, and bailout thresholds for conversion to vascular resection.
+
+## Attending Pearls from Conference
+
+- Review surgeon-specific anastomotic preferences during pre-op huddle.
+- Clarify DVT prophylaxis restart timing because this attending prefers early postoperative anticoagulation.

--- a/_config.yml
+++ b/_config.yml
@@ -198,6 +198,13 @@ date_format: "%B %-d, %Y"
 # Output options (more information on Jekyll's site)
 timezone: "America/Toronto"
 markdown: kramdown
+collections:
+  topic_reviews:
+    output: true
+    permalink: /landmark/topic-review/:name/
+  case_preps:
+    output: true
+    permalink: /landmark/case-prep/:name/
 highlighter: rouge
 permalink: /:year-:month-:day-:title/
 paginate: 5

--- a/_includes/landmark-nav.html
+++ b/_includes/landmark-nav.html
@@ -24,6 +24,15 @@
         <li class="nav-item">
           <a class="nav-link" href="/landmark">Table of Contents</a>
         </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="studyToolsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Study Tools
+          </a>
+          <div class="dropdown-menu" aria-labelledby="studyToolsDropdown">
+            <a class="dropdown-item" href="/landmark/topic-review/">Topic Reviews</a>
+            <a class="dropdown-item" href="/landmark/case-prep/">Case Prep Library</a>
+          </div>
+        </li>
       </ul>
 
       <!-- Search bar -->

--- a/_layouts/case-prep.html
+++ b/_layouts/case-prep.html
@@ -1,0 +1,295 @@
+---
+layout: none
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ page.title }} – Case Prep</title>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
+  <style>
+    :root {
+      --navy: #0C2C47;
+      --green: #2D5652;
+      --yellow: #E2A54D;
+      --aqua: #97D3CD;
+      --pink: #EFEAE6;
+      --mint: #E4F2EA;
+      --beige: #F8F5F0;
+      --text: #1a1a1a;
+      --muted: #555;
+      --card: #ffffff;
+      --border: #e0e0e0;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--beige);
+      color: var(--text);
+      font-family: 'Source Serif 4', serif;
+      line-height: 1.7;
+    }
+
+    a {
+      color: var(--green);
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: var(--aqua);
+      text-decoration: underline;
+    }
+
+    main {
+      max-width: 1024px;
+      margin: 4rem auto;
+      background: var(--card);
+      padding: 3rem;
+      border-radius: 20px;
+      box-shadow: 0 4px 18px rgba(0,0,0,0.08);
+    }
+
+    header.study-header {
+      display: grid;
+      gap: 1.25rem;
+      margin-bottom: 2.5rem;
+    }
+
+    h1 {
+      font-family: 'Manrope', sans-serif;
+      font-size: 2.5rem;
+      margin: 0;
+      color: var(--navy);
+    }
+
+    .study-eyebrow {
+      font-family: 'Manrope', sans-serif;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1rem;
+      color: var(--muted);
+    }
+
+    .meta-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+
+    .meta-card {
+      background: var(--mint);
+      border-radius: 14px;
+      padding: 1.25rem 1.5rem;
+      font-family: 'Manrope', sans-serif;
+    }
+
+    .meta-card h3 {
+      margin: 0 0 0.35rem 0;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08rem;
+      color: var(--green);
+    }
+
+    .meta-card p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--navy);
+    }
+
+    section {
+      margin-top: 2.5rem;
+    }
+
+    section h2 {
+      font-family: 'Manrope', sans-serif;
+      font-size: 1.6rem;
+      margin-bottom: 1rem;
+      color: var(--navy);
+      border-bottom: 2px solid var(--mint);
+      padding-bottom: 0.35rem;
+    }
+
+    ul, ol {
+      padding-left: 1.5rem;
+    }
+
+    ul li, ol li {
+      margin-bottom: 0.6rem;
+      font-size: 1.05rem;
+    }
+
+    .pimp-questions dt {
+      font-weight: 700;
+      font-family: 'Manrope', sans-serif;
+      color: var(--navy);
+      margin-top: 1rem;
+    }
+
+    .pimp-questions dd {
+      margin-left: 0;
+      margin-bottom: 0.75rem;
+    }
+
+    .content-notes {
+      background: var(--pink);
+      border-left: 4px solid var(--yellow);
+      padding: 1.5rem 1.75rem;
+      border-radius: 16px;
+    }
+
+    .checklist {
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .checklist li::before {
+      content: "\2713";
+      color: var(--green);
+      margin-right: 0.75rem;
+      font-weight: 700;
+    }
+
+    @media (max-width: 768px) {
+      main {
+        margin: 2rem 1rem;
+        padding: 2.25rem;
+      }
+
+      h1 {
+        font-size: 2.1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  {% include landmark-nav.html %}
+  <main class="study-page case-prep">
+    <header class="study-header">
+      {% if page.exam_focus %}
+        <div class="study-eyebrow">{{ page.exam_focus }}</div>
+      {% endif %}
+      <h1>{{ page.title }}</h1>
+      <div class="meta-grid">
+        {% if page.difficulty %}
+          <div class="meta-card">
+            <h3>Complexity</h3>
+            <p>{{ page.difficulty }}</p>
+          </div>
+        {% endif %}
+        {% if page.time_goal %}
+          <div class="meta-card">
+            <h3>Time Goal</h3>
+            <p>{{ page.time_goal }}</p>
+          </div>
+        {% endif %}
+        {% if page.attending_notes %}
+          <div class="meta-card">
+            <h3>Attending Notes</h3>
+            <p>{{ page.attending_notes }}</p>
+          </div>
+        {% endif %}
+        {% if page.patient_profile %}
+          <div class="meta-card">
+            <h3>Patient Snapshot</h3>
+            <p>{{ page.patient_profile }}</p>
+          </div>
+        {% endif %}
+      </div>
+    </header>
+
+    {% if page.high_yield_pearls %}
+      <section class="high-yield-pearls">
+        <h2>High-Yield Pearls</h2>
+        <ul>
+          {% for pearl in page.high_yield_pearls %}
+            <li>{{ pearl }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.workflow_steps %}
+      <section class="workflow">
+        <h2>10-Step Workflow</h2>
+        <ol>
+          {% for step in page.workflow_steps %}
+            <li>{{ step }}</li>
+          {% endfor %}
+        </ol>
+      </section>
+    {% endif %}
+
+    {% if page.preop_checklist %}
+      <section class="preop-checklist">
+        <h2>Pre-Op Checklist</h2>
+        <ul class="checklist">
+          {% for item in page.preop_checklist %}
+            <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.pimp_questions %}
+      <section class="pimp-questions">
+        <h2>Pimp Questions</h2>
+        <dl>
+          {% for item in page.pimp_questions %}
+            <dt>{{ item.question }}</dt>
+            {% if item.answer %}
+              <dd>{{ item.answer }}</dd>
+            {% endif %}
+          {% endfor %}
+        </dl>
+      </section>
+    {% endif %}
+
+    {% if page.anatomy_maps %}
+      <section class="anatomy">
+        <h2>Anatomy Maps</h2>
+        <ul>
+          {% for map in page.anatomy_maps %}
+            {% assign label = map.title | default: map %}
+            {% assign details = map.details %}
+            <li>
+              <strong>{{ label }}</strong>{% if details %}: {{ details }}{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.attending_specific_comments %}
+      <section class="attending-comments">
+        <h2>Attending-Specific Comments</h2>
+        <ul>
+          {% for comment in page.attending_specific_comments %}
+            <li>{{ comment }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.reading_list %}
+      <section class="reading-list">
+        <h2>Suggested Reading</h2>
+        <ul>
+          {% for ref in page.reading_list %}
+            <li>{{ ref }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if content %}
+      <section class="content-notes">
+        {{ content }}
+      </section>
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/_layouts/topic-review.html
+++ b/_layouts/topic-review.html
@@ -1,0 +1,275 @@
+---
+layout: none
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ page.title }} – Topic Review</title>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
+  <style>
+    :root {
+      --navy: #0C2C47;
+      --green: #2D5652;
+      --yellow: #E2A54D;
+      --aqua: #97D3CD;
+      --pink: #EFEAE6;
+      --mint: #E4F2EA;
+      --beige: #F8F5F0;
+      --text: #1a1a1a;
+      --muted: #555;
+      --card: #ffffff;
+      --border: #e0e0e0;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--beige);
+      color: var(--text);
+      font-family: 'Source Serif 4', serif;
+      line-height: 1.7;
+    }
+
+    a {
+      color: var(--green);
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: var(--aqua);
+      text-decoration: underline;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 4rem auto;
+      background: var(--card);
+      padding: 2.75rem;
+      border-radius: 20px;
+      box-shadow: 0 4px 18px rgba(0,0,0,0.08);
+    }
+
+    header.study-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .study-eyebrow {
+      font-family: 'Manrope', sans-serif;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1rem;
+      color: var(--muted);
+    }
+
+    h1 {
+      font-family: 'Manrope', sans-serif;
+      font-size: 2.4rem;
+      margin: 0;
+      color: var(--navy);
+    }
+
+    .meta-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .meta-card {
+      background: var(--mint);
+      border-radius: 14px;
+      padding: 1rem 1.25rem;
+      font-family: 'Manrope', sans-serif;
+    }
+
+    .meta-card h3 {
+      margin: 0 0 0.25rem 0;
+      font-size: 0.85rem;
+      letter-spacing: 0.08rem;
+      text-transform: uppercase;
+      color: var(--green);
+    }
+
+    .meta-card p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--navy);
+    }
+
+    section {
+      margin-top: 2.5rem;
+    }
+
+    section h2 {
+      font-family: 'Manrope', sans-serif;
+      font-size: 1.6rem;
+      margin-bottom: 1rem;
+      color: var(--navy);
+      border-bottom: 2px solid var(--mint);
+      padding-bottom: 0.35rem;
+    }
+
+    ul, ol {
+      padding-left: 1.4rem;
+    }
+
+    ul li, ol li {
+      margin-bottom: 0.6rem;
+      font-size: 1.05rem;
+    }
+
+    .pimp-questions dt {
+      font-weight: 700;
+      font-family: 'Manrope', sans-serif;
+      color: var(--navy);
+      margin-top: 1rem;
+    }
+
+    .pimp-questions dd {
+      margin-left: 0;
+      margin-bottom: 0.75rem;
+    }
+
+    .reading-list ul {
+      list-style: square;
+    }
+
+    .content-notes {
+      background: var(--pink);
+      border-left: 4px solid var(--yellow);
+      padding: 1.25rem 1.5rem;
+      border-radius: 14px;
+    }
+
+    @media (max-width: 768px) {
+      main {
+        margin: 2rem 1rem;
+        padding: 2rem;
+      }
+
+      h1 {
+        font-size: 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  {% include landmark-nav.html %}
+  <main class="study-page topic-review">
+    <header class="study-header">
+      {% if page.exam_focus %}
+        <div class="study-eyebrow">{{ page.exam_focus }}</div>
+      {% endif %}
+      <h1>{{ page.title }}</h1>
+      {% if page.subtitle %}
+        <p class="page-subtitle">{{ page.subtitle }}</p>
+      {% endif %}
+      <div class="meta-grid">
+        {% if page.difficulty %}
+          <div class="meta-card">
+            <h3>Difficulty</h3>
+            <p>{{ page.difficulty }}</p>
+          </div>
+        {% endif %}
+        {% if page.time_goal %}
+          <div class="meta-card">
+            <h3>Time Goal</h3>
+            <p>{{ page.time_goal }}</p>
+          </div>
+        {% endif %}
+        {% if page.attending_notes %}
+          <div class="meta-card">
+            <h3>Attending Notes</h3>
+            <p>{{ page.attending_notes }}</p>
+          </div>
+        {% endif %}
+      </div>
+    </header>
+
+    {% if page.high_yield_pearls %}
+      <section class="high-yield-pearls">
+        <h2>High-Yield Pearls</h2>
+        <ul>
+          {% for pearl in page.high_yield_pearls %}
+            <li>{{ pearl }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.workflow_steps %}
+      <section class="workflow">
+        <h2>10-Step Workflow</h2>
+        <ol>
+          {% for step in page.workflow_steps %}
+            <li>{{ step }}</li>
+          {% endfor %}
+        </ol>
+      </section>
+    {% endif %}
+
+    {% if page.pimp_questions %}
+      <section class="pimp-questions">
+        <h2>Pimp Questions</h2>
+        <dl>
+          {% for item in page.pimp_questions %}
+            <dt>{{ item.question }}</dt>
+            {% if item.answer %}
+              <dd>{{ item.answer }}</dd>
+            {% endif %}
+          {% endfor %}
+        </dl>
+      </section>
+    {% endif %}
+
+    {% if page.anatomy_maps %}
+      <section class="anatomy">
+        <h2>Anatomy Maps</h2>
+        <ul>
+          {% for map in page.anatomy_maps %}
+            {% assign label = map.title | default: map %}
+            {% assign details = map.details %}
+            <li>
+              <strong>{{ label }}</strong>{% if details %}: {{ details }}{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.attending_specific_comments %}
+      <section class="attending-comments">
+        <h2>Attending-Specific Comments</h2>
+        <ul>
+          {% for comment in page.attending_specific_comments %}
+            <li>{{ comment }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if page.reading_list %}
+      <section class="reading-list">
+        <h2>Suggested Reading</h2>
+        <ul>
+          {% for ref in page.reading_list %}
+            <li>{{ ref }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {% if content %}
+      <section class="content-notes">
+        {{ content }}
+      </section>
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/_topic_reviews/abdominal-compartment-syndrome.md
+++ b/_topic_reviews/abdominal-compartment-syndrome.md
@@ -1,0 +1,51 @@
+---
+layout: topic-review
+title: "Abdominal Compartment Syndrome"
+exam_focus: "ABSITE, Oral Boards"
+difficulty: "Advanced"
+attending_notes: "Dr. Murphy expects rapid recognition of ACS triggers and escalation steps."
+time_goal: "15-minute rapid review"
+high_yield_pearls:
+  - "Suspect ACS in any patient with rising ventilator pressures, oliguria, and tense abdomen."
+  - "Measure bladder pressure every 4 hours when IAP risk factors accumulate."
+  - "Decompress early when intra-abdominal pressure remains > 20 mmHg with new organ dysfunction."
+workflow_steps:
+  - "Screen for risk factors: massive resuscitation, burns, pancreatitis, trauma."
+  - "Perform focused exam and trend ventilator, UOP, and lactate data."
+  - "Obtain baseline bladder pressure and optimize sedation/neuromuscular blockade."
+  - "Initiate medical decompression: NG/rectal tubes, prokinetics, diuretics."
+  - "Optimize abdominal wall compliance with analgesia and repositioning."
+  - "Escalate to percutaneous drainage when tense ascites or hemoperitoneum is present."
+  - "Coordinate OR decompressive laparotomy if IAP > 25 mmHg with organ failure."
+  - "Pack viscera, place negative pressure dressing, and chart temporary closure plan."
+  - "Resuscitate to maintain perfusion: balanced transfusion, avoid over-resuscitation."
+  - "Plan staged closure and monitor for recurrent ACS in the ICU."
+pimp_questions:
+  - question: "What threshold defines intra-abdominal hypertension?"
+    answer: ">= 12 mmHg of sustained intra-abdominal pressure."
+  - question: "How do you calculate abdominal perfusion pressure?"
+    answer: "Mean arterial pressure minus intra-abdominal pressure; goal > 60 mmHg."
+  - question: "Name three temporizing measures before decompressive laparotomy."
+    answer: "Paralysis, nasogastric decompression, and percutaneous drainage of fluid collections."
+anatomy_maps:
+  - title: "Abdominal compartments"
+    details: "Understand planes formed by costal margins, iliac crests, and retroperitoneum when planning decompression."
+  - title: "Open abdomen coverage"
+    details: "Review fascia layers and vascular arcades relevant to negative pressure dressing placement."
+attending_specific_comments:
+  - "Document serial bladder pressures in the operative note for ICU handoff."
+  - "Clarify postoperative closure strategy with acute care surgery service."
+reading_list:
+  - "WSACS Guidelines 2013"
+  - "Surgical Clinics of North America 2021 review on open abdomen management"
+---
+
+## Quick Reference Narrative
+
+Use this summary to rehearse the pathophysiology, recognition, and staged management of abdominal compartment syndrome before rounds or call nights.
+
+## Expanded Notes
+
+- Watch for fluid creep in massive transfusion patients and titrate balanced resuscitation strategies.
+- Coordinate with critical care early when bladder pressures begin to climb to 12 mmHg.
+- After decompression, reassess ventilator mechanics, renal perfusion, and abdominal perfusion pressure every hour.

--- a/landmark/case-prep/index.md
+++ b/landmark/case-prep/index.md
@@ -1,0 +1,70 @@
+---
+layout: landmark
+title: Case Prep Library
+permalink: /landmark/case-prep/
+---
+
+## Case Prep Playbook
+
+Plan your operative run-throughs with structured case prep guides tailored to the Landmark curriculum.
+
+{% assign cases = site.case_preps | sort: 'title' %}
+<div class="card-list">
+  {% for case in cases %}
+    <div class="card">
+      <h3><a href="{{ case.url | relative_url }}">{{ case.title }}</a></h3>
+      <p class="card-meta">{{ case.exam_focus }}{% if case.difficulty %} • {{ case.difficulty }}{% endif %}</p>
+      {% if case.patient_profile %}
+        <p class="card-body">{{ case.patient_profile }}</p>
+      {% endif %}
+      {% if case.workflow_steps %}
+        <ol>
+          {% for step in case.workflow_steps limit:3 %}
+            <li>{{ step }}</li>
+          {% endfor %}
+        </ol>
+      {% endif %}
+      <a class="card-link" href="{{ case.url | relative_url }}">Open the case prep →</a>
+    </div>
+  {% endfor %}
+</div>
+
+<style>
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.08);
+  border: 1px solid rgba(12,44,71,0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card-meta {
+  font-style: italic;
+  color: #2D5652;
+  font-size: 0.95rem;
+}
+
+.card-body {
+  margin: 0.5rem 0 0.75rem 0;
+}
+
+.card ol {
+  padding-left: 1.2rem;
+  margin: 0.75rem 0 1rem 0;
+}
+
+.card-link {
+  font-weight: 600;
+}
+</style>

--- a/landmark/index.md
+++ b/landmark/index.md
@@ -7,6 +7,11 @@ permalink: /landmark/
 
 Welcome to the Landmark Papers collection — a curated set of high-impact surgical trials used for education and clinical reference.
 
+## Study Tools
+
+- [Topic Reviews](/landmark/topic-review/)
+- [Case Prep Library](/landmark/case-prep/)
+
 ---
 
 - [FOCUS](/landmark/focus)

--- a/landmark/topic-review/index.md
+++ b/landmark/topic-review/index.md
@@ -1,0 +1,63 @@
+---
+layout: landmark
+title: Topic Reviews
+permalink: /landmark/topic-review/
+---
+
+## Curated Topic Reviews
+
+Use these rapid-fire topic reviews to refresh high-yield information before exams, rounds, or call.
+
+{% assign reviews = site.topic_reviews | sort: 'title' %}
+<div class="card-list">
+  {% for review in reviews %}
+    <div class="card">
+      <h3><a href="{{ review.url | relative_url }}">{{ review.title }}</a></h3>
+      <p class="card-meta">{{ review.exam_focus }}{% if review.difficulty %} • {{ review.difficulty }}{% endif %}</p>
+      {% if review.high_yield_pearls %}
+        <ul>
+          {% for pearl in review.high_yield_pearls limit:2 %}
+            <li>{{ pearl }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      <a class="card-link" href="{{ review.url | relative_url }}">Read the full review →</a>
+    </div>
+  {% endfor %}
+</div>
+
+<style>
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.08);
+  border: 1px solid rgba(12,44,71,0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card-meta {
+  font-style: italic;
+  color: #2D5652;
+  font-size: 0.95rem;
+}
+
+.card ul {
+  padding-left: 1.2rem;
+  margin: 0.75rem 0 1rem 0;
+}
+
+.card-link {
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
## Summary
- add topic review and case prep collections with dedicated listing pages under the Landmark section
- create reusable layouts that surface metadata-driven sections for new study guides
- seed the collections with starter guides and expose them from the Landmark landing page and navigation

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c2612fdc8326ae33d481f6bb128a