### PR TITLE
Add Case Prep community submission workflow

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -177,13 +177,12 @@ feed_show_tags: false
 # If you want to use reCaptcha for staticman (optional for spam protection), then fill
 # in the "siteKey" and "secret" parameters below and also in `staticman.yml`.
 # See more details at https://staticman.net/
-#staticman:
-#  repository : # GitHub username/repository eg. "daattali/beautiful-jekyll"
-#  branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-#  endpoint   : # (optional) URL of your own deployment, with a trailing slash eg. https://<your-api>/v3/entry/github/ (will fallback to a public GitLab instance)
-#  reCaptcha:
-#    siteKey  : # Use your own site key, you need to apply for one on Google
-#    secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
+staticman:
+  repository: nkreid/nkreid.github.io
+  branch: work
+  endpoint: https://staticman3.herokuapp.com/v3/entry/github/
+  reCaptcha:
+    enabled: false
 
 # --- Misc --- #
 

--- a/_layouts/case-prep.html
+++ b/_layouts/case-prep.html
@@ -1,0 +1,120 @@
+---
+layout: base
+---
+
+{% include header.html type="page" %}
+
+{% assign computed_case_id = page.case_id | default: page.slug | default: page.title %}
+{% assign case_id = computed_case_id | slugify %}
+{% assign updates_root = site.data['case-prep-updates'] %}
+{% if updates_root == nil %}
+  {% assign updates_root = {} %}
+{% endif %}
+{% assign case_updates_map = updates_root[case_id] %}
+{% assign case_updates_list = "" | split: "" %}
+{% if case_updates_map %}
+  {% for update_entry in case_updates_map %}
+    {% assign case_updates_list = case_updates_list | push: update_entry[1] %}
+  {% endfor %}
+{% endif %}
+{% assign approved_updates = case_updates_list | where_exp: "item", "item.approved == true" %}
+{% assign sorted_updates = approved_updates | sort: 'date' | reverse %}
+
+<div class="{% if page.full-width %} container-fluid {% else %} container-md {% endif %}" role="main">
+  <div class="row">
+    <div class="{% if page.full-width %} col {% else %} col-xl-8 offset-xl-2 col-lg-10 offset-lg-1 {% endif %}">
+      <article class="case-prep-canonical">
+        {{ content }}
+      </article>
+
+      <section id="case-prep-community-updates" class="case-prep-updates mt-5">
+        <h2>Community Updates</h2>
+        {% if sorted_updates and sorted_updates.size > 0 %}
+          {% for entry in sorted_updates %}
+            <article class="case-prep-update mb-4 pb-4 border-bottom">
+              <header class="mb-2">
+                <h3 class="h5 mb-1">{% if entry.name %}{{ entry.name }}{% else %}Community submission{% endif %}</h3>
+                <p class="text-muted small mb-0">
+                  Submitted on {{ entry.date | date: "%B %-d, %Y" }}
+                  {% if entry.attending_comments %}
+                    · Includes attending commentary
+                  {% endif %}
+                </p>
+              </header>
+
+              {% if entry.steps %}
+                <h4 class="h6 mt-3">Updated Steps</h4>
+                <div class="case-prep-update-steps">{{ entry.steps | markdownify }}</div>
+              {% endif %}
+
+              {% if entry.pimp_questions %}
+                <h4 class="h6 mt-3">Pimp Questions</h4>
+                <div class="case-prep-update-questions">{{ entry.pimp_questions | markdownify }}</div>
+              {% endif %}
+
+              {% if entry.anatomy_pearls %}
+                <h4 class="h6 mt-3">Anatomy Pearls</h4>
+                <div class="case-prep-update-anatomy">{{ entry.anatomy_pearls | markdownify }}</div>
+              {% endif %}
+
+              {% if entry.attending_comments %}
+                <h4 class="h6 mt-3">Attending Comments</h4>
+                <div class="case-prep-update-attending">{{ entry.attending_comments | markdownify }}</div>
+              {% endif %}
+            </article>
+          {% endfor %}
+        {% else %}
+          <p class="text-muted">No approved community updates have been published for this case yet. Submit your insights below!</p>
+        {% endif %}
+      </section>
+
+      <section id="submit-case-prep-update" class="case-prep-form mt-5">
+        <h2>Submit an Update</h2>
+        <p class="lead">Share refinements to the operative steps, pimp questions, anatomy pearls, or attending insights so future learners benefit.</p>
+        <p class="text-muted">All submissions are held for moderation before appearing on this page.</p>
+
+        {% if site.staticman and site.staticman.endpoint and site.staticman.repository and site.staticman.branch %}
+          <form method="POST" action="{{ site.staticman.endpoint }}{{ site.staticman.repository }}/{{ site.staticman.branch }}/case-prep" class="needs-validation" novalidate>
+            <input type="hidden" name="options[redirect]" value="{{ page.url | absolute_url }}#submit-case-prep-update">
+            <input type="hidden" name="options[origin]" value="{{ page.url | absolute_url }}">
+            <input type="hidden" name="options[case_id]" value="{{ case_id }}">
+
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label" for="case-prep-name">Name <span class="text-muted">(optional)</span></label>
+                <input type="text" id="case-prep-name" name="fields[name]" class="form-control" placeholder="Your name or team">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="case-prep-email">Email <span class="text-muted">(optional, kept private)</span></label>
+                <input type="email" id="case-prep-email" name="fields[email]" class="form-control" placeholder="name@example.com">
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="case-prep-steps">Updated Steps <span class="text-danger">*</span></label>
+                <textarea id="case-prep-steps" name="fields[steps]" class="form-control" rows="5" required placeholder="Walk through the refined steps, instruments, or decision points."></textarea>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="case-prep-questions">Pimp Questions</label>
+                <textarea id="case-prep-questions" name="fields[pimp_questions]" class="form-control" rows="4" placeholder="List rapid-fire questions or oral board prompts."></textarea>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="case-prep-anatomy">Anatomy Pearls</label>
+                <textarea id="case-prep-anatomy" name="fields[anatomy_pearls]" class="form-control" rows="4" placeholder="Highlight must-know anatomy or exposures."></textarea>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="case-prep-attending">Attending Comments</label>
+                <textarea id="case-prep-attending" name="fields[attending_comments]" class="form-control" rows="3" placeholder="Share memorable quotes, mantras, or preferences from attendings."></textarea>
+              </div>
+              <div class="col-12">
+                <button type="submit" class="btn btn-primary">Submit Update</button>
+              </div>
+            </div>
+          </form>
+        {% else %}
+          <div class="alert alert-warning" role="alert">
+            Staticman is not configured. Please contact the site maintainer to enable community submissions.
+          </div>
+        {% endif %}
+      </section>
+    </div>
+  </div>
+</div>

--- a/case-prep/index.md
+++ b/case-prep/index.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Case Prep
+permalink: /case-prep/
+---
+
+# Case Prep
+
+The Case Prep series distills go-to operative steps, anatomy pearls, and pimp questions for high-yield surgical scenarios. Each case page now includes a community contribution form so the playbook continues to evolve alongside modern practice.
+
+## How to share an update
+
+1. Open the specific case page you want to refine.
+2. Scroll to the "Submit an Update" form beneath the canonical content.
+3. Add refreshed operative steps, rapid-fire questions, anatomy pearls, or attending comments. Markdown formatting is supported for bullets and emphasis.
+4. Hit **Submit Update** to send it for review.
+
+## What happens next?
+
+- **Moderation cadence:** New submissions are reviewed in batches every Friday. Expect approved updates to publish within 7 days of submission.
+- **Notification:** Staticman does not automatically email status changes. If you include an email, it is only used for follow-up questions from the editorial team.
+- **Approval standard:** Updates should cite contemporary practice patterns, highlight safety pearls, or clarify decision points. Submissions that lack clear educational value may be declined.
+
+## Need help?
+
+Questions about the workflow or a pending update? Email [neil.k.reid@gmail.com](mailto:neil.k.reid@gmail.com) and include the case name plus submission date so we can track it down quickly.
+
+Ready to dive in? Explore the cases from the main surgery curriculum and keep the knowledge fresh for the next call night.

--- a/staticman.yml
+++ b/staticman.yml
@@ -25,7 +25,7 @@ comments:
   #
   # Name of the branch being used. Must match the `branch` in the theme config
   # file.
-  branch: "master"   #  use "master" for user page or "gh-pages" for project pages
+  branch: "work"   #  use "master" for user page or "gh-pages" for project pages
 
   commitMessage: "New comment by {fields.name}"
 
@@ -108,3 +108,22 @@ comments:
     # i.e. https://{STATICMAN API INSTANCE}/v3/encrypt/{your-site-secret}
     # For more information, visit https://staticman.net/docs/encryption
     #secret: ""
+
+case-prep:
+  allowedFields: ["name", "email", "steps", "pimp_questions", "anatomy_pearls", "attending_comments"]
+  branch: "work"
+  commitMessage: "Case Prep update for {options.case_id}"
+  filename: "{options.case_id}-{@timestamp}"
+  format: "yaml"
+  generatedFields:
+    date:
+      type: "date"
+      options:
+        format: "iso8601"
+  moderation: true
+  path: "_data/case-prep-updates/{options.case_id}"
+  requiredFields: ["steps"]
+  transforms:
+    email: md5
+  reCaptcha:
+    enabled: false


### PR DESCRIPTION
## Summary
- configure Staticman with the site repository and enable a dedicated Case Prep submission pipeline
- create a Case Prep layout that renders approved community updates and exposes a Staticman contribution form
- document how to submit Case Prep updates on the landing page and add storage for reviewed entries

## Testing
- not run (bundle exec jekyll build)


------
https://chatgpt.com/codex/tasks/task_e_68e2c262b0dc832699546ea23c6ccb46