### PR TITLE
Unify Landmark layouts under a shared header

### DIFF
--- a/Landmark/index.md
+++ b/Landmark/index.md
@@ -4,6 +4,7 @@ title: "Landmark Learning Hub"
 permalink: /landmark/
 hide_page_title: true
 hide_page_subtitle: true
+toc: false
 ---
 
 <div class="landing-grid">

--- a/_includes/landmark-nav.html
+++ b/_includes/landmark-nav.html
@@ -1,45 +1,11 @@
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <div class="container">
-    <a class="navbar-brand" href="/landmark">
-      <img src="{{ '/assets/img/NKR_white.png' | relative_url }}" alt="NKR Logo" style="height: 30px;" />
-    </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarLandmark" aria-controls="navbarLandmark" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarLandmark">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="papersDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Papers
-          </a>
-          <div class="dropdown-menu" aria-labelledby="papersDropdown">
-            <!-- Add your fixed TOC links here -->
-            <a class="dropdown-item" href="/landmark/focus">FOCUS</a>
-            <a class="dropdown-item" href="/landmark/tricc">TRICC</a>
-            <a class="dropdown-item" href="/landmark/proppr">PROPPR</a>
-            <!-- ... -->
-          </div>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/landmark">Table of Contents</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="studyToolsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Study Tools
-          </a>
-          <div class="dropdown-menu" aria-labelledby="studyToolsDropdown">
-            <a class="dropdown-item" href="/landmark/topic-review/">Topic Reviews</a>
-            <a class="dropdown-item" href="/landmark/case-prep/">Case Prep Library</a>
-          </div>
-        </li>
-      </ul>
-
-      <!-- Search bar -->
-      <form class="form-inline my-2 my-lg-0" action="/landmark/search.html" method="get">
-        <input class="form-control mr-sm-2" type="search" placeholder="Search papers" aria-label="Search" name="query">
-        <button class="btn btn-outline-light my-2 my-sm-0" type="submit">Search</button>
-      </form>
-    </div>
-  </div>
-</nav>
+<header>
+  <a class="brand" href="/landmark">
+    <img src="/assets/img/NKR_white.png" alt="NKR logo">
+    <span class="brand-text">Surgery Study Hub</span>
+  </a>
+  <nav class="nav-actions" aria-label="Primary navigation">
+    <a class="nav-button" href="/landmark/paper-review/">Papers</a>
+    <a class="nav-button" href="/landmark/topic-review/">Topics</a>
+    <a class="nav-button" href="/landmark/case-prep/">Surgeries</a>
+  </nav>
+</header>

--- a/_layouts/case-prep.html
+++ b/_layouts/case-prep.html
@@ -43,6 +43,72 @@ layout: none
       text-decoration: underline;
     }
 
+    header {
+      background: var(--navy);
+      color: white;
+      padding: 1.25rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 2rem;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+      color: white;
+    }
+
+    .brand img {
+      height: 64px;
+      width: auto;
+      object-fit: contain;
+    }
+
+    .brand-text {
+      font-family: 'Manrope', sans-serif;
+      font-size: 1.65rem;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+
+    .nav-actions {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      margin-left: auto;
+      flex-wrap: wrap;
+      font-family: 'Manrope', sans-serif;
+    }
+
+    .nav-button {
+      background: white;
+      color: var(--navy);
+      padding: 0.6rem 1.4rem;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      box-shadow: 0 8px 18px rgba(12, 44, 71, 0.16);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .nav-button:hover,
+    .nav-button:focus {
+      background: var(--aqua);
+      color: var(--navy);
+      transform: translateY(-1px);
+      text-decoration: none;
+      box-shadow: 0 12px 24px rgba(12, 44, 71, 0.22);
+    }
+
     main {
       max-width: 1024px;
       margin: 4rem auto;
@@ -161,6 +227,28 @@ layout: none
 
       h1 {
         font-size: 2.1rem;
+      }
+
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .nav-actions {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 0.75rem;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .nav-actions {
+        gap: 0.6rem;
+      }
+
+      .nav-button {
+        width: 100%;
+        justify-content: center;
       }
     }
   </style>

--- a/_layouts/landmark.html
+++ b/_layouts/landmark.html
@@ -297,17 +297,12 @@ layout: none
 <body>
 
   <!-- NAVBAR -->
-  <header>
-    <a class="brand" href="/landmark">
-      <img src="/assets/img/NKR_white.png" alt="NKR logo">
-      <span class="brand-text">Surgery Study Hub</span>
-    </a>
-    <nav class="nav-actions" aria-label="Primary navigation">
-      <a class="nav-button" href="/landmark/paper-review/">Papers</a>
-      <a class="nav-button" href="/landmark/topic-review/">Topics</a>
-      <a class="nav-button" href="/landmark/case-prep/">Surgeries</a>
-    </nav>
-  </header>
+  {% include landmark-nav.html %}
+
+  {% assign show_toc = page.toc %}
+  {% if show_toc == nil %}
+    {% assign show_toc = true %}
+  {% endif %}
 
   <!-- MAIN CONTENT -->
   <main class="content-wrapper">
@@ -321,11 +316,14 @@ layout: none
       {{ content }}
     </div>
 
+    {% if show_toc %}
     <nav class="toc-box">
       <ul></ul>
     </nav>
+    {% endif %}
   </main>
 
+  {% if show_toc %}
   <!-- TOC JS -->
   <script>
     document.addEventListener("DOMContentLoaded", function () {
@@ -356,5 +354,6 @@ layout: none
       }
     });
   </script>
+  {% endif %}
 </body>
 </html>

--- a/_layouts/topic-review.html
+++ b/_layouts/topic-review.html
@@ -43,6 +43,72 @@ layout: none
       text-decoration: underline;
     }
 
+    header {
+      background: var(--navy);
+      color: white;
+      padding: 1.25rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 2rem;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+      color: white;
+    }
+
+    .brand img {
+      height: 64px;
+      width: auto;
+      object-fit: contain;
+    }
+
+    .brand-text {
+      font-family: 'Manrope', sans-serif;
+      font-size: 1.65rem;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+
+    .nav-actions {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      margin-left: auto;
+      flex-wrap: wrap;
+      font-family: 'Manrope', sans-serif;
+    }
+
+    .nav-button {
+      background: white;
+      color: var(--navy);
+      padding: 0.6rem 1.4rem;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      box-shadow: 0 8px 18px rgba(12, 44, 71, 0.16);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .nav-button:hover,
+    .nav-button:focus {
+      background: var(--aqua);
+      color: var(--navy);
+      transform: translateY(-1px);
+      text-decoration: none;
+      box-shadow: 0 12px 24px rgba(12, 44, 71, 0.22);
+    }
+
     main {
       max-width: 960px;
       margin: 4rem auto;
@@ -155,6 +221,28 @@ layout: none
 
       h1 {
         font-size: 2rem;
+      }
+
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .nav-actions {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 0.75rem;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .nav-actions {
+        gap: 0.6rem;
+      }
+
+      .nav-button {
+        width: 100%;
+        justify-content: center;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- replace the old Bootstrap landmark nav include with the new Landmark header used on the hub
- update the case prep and topic review layouts to share the same sticky header styling as the Landmark landing page
- disable the floating table of contents on the Landmark hub so it only renders the three feature cards

## Testing
- bundle install *(fails: 403 Forbidden when fetching gems in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e2de35a08326a481884a0f02db0b