### PR TITLE
Simplify case prep layout and remove page subtitles

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,15 +28,6 @@
       <div class="col-xl-8 offset-xl-2 col-lg-10 offset-lg-1">
         <div class="{{ include.type }}-heading">
           <h1>{% if page.title %}{{ page.title }}{% else %}<br/>{% endif %}</h1>
-          {% if page.subtitle %}
-            {% if include.type == "page" %}
-              <hr class="small">
-              <span class="{{ include.type }}-subheading">{{ page.subtitle }}</span>
-            {% else %}
-              <h2 class="{{ include.type }}-subheading">{{ page.subtitle }}</h2>
-            {% endif %}
-          {% endif %}
-
           {% if include.type == "post" %}
             <span class="post-meta">Posted on {{ page.date | date: date_format }}</span>
             {% if page.last-updated %}
@@ -62,15 +53,6 @@
       <div class="col-xl-8 offset-xl-2 col-lg-10 offset-lg-1">
         <div class="{{ include.type }}-heading">
           <h1>{% if page.title %}{{ page.title }}{% else %}<br/>{% endif %}</h1>
-          {% if page.subtitle %}
-            {% if include.type == "page" %}
-              <hr class="small">
-              <span class="{{ include.type }}-subheading">{{ page.subtitle }}</span>
-            {% else %}
-              <h2 class="{{ include.type }}-subheading">{{ page.subtitle }}</h2>
-            {% endif %}
-          {% endif %}
-
           {% if include.type == "post" %}
             <span class="post-meta">Posted on {{ page.date | date: date_format }}</span>
             {% if page.last-updated %}

--- a/_layouts/case-prep.html
+++ b/_layouts/case-prep.html
@@ -118,51 +118,10 @@ layout: none
       box-shadow: 0 4px 18px rgba(0,0,0,0.08);
     }
 
-    header.study-header {
-      display: grid;
-      gap: 1.25rem;
-      margin-bottom: 2.5rem;
-    }
-
-    h1 {
+    .case-title {
       font-family: 'Manrope', sans-serif;
       font-size: 2.5rem;
-      margin: 0;
-      color: var(--navy);
-    }
-
-    .study-eyebrow {
-      font-family: 'Manrope', sans-serif;
-      font-size: 0.95rem;
-      text-transform: uppercase;
-      letter-spacing: 0.1rem;
-      color: var(--muted);
-    }
-
-    .meta-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 1rem;
-    }
-
-    .meta-card {
-      background: var(--mint);
-      border-radius: 14px;
-      padding: 1.25rem 1.5rem;
-      font-family: 'Manrope', sans-serif;
-    }
-
-    .meta-card h3 {
-      margin: 0 0 0.35rem 0;
-      font-size: 0.85rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08rem;
-      color: var(--green);
-    }
-
-    .meta-card p {
-      margin: 0;
-      font-size: 1.05rem;
+      margin: 0 0 2rem;
       color: var(--navy);
     }
 
@@ -225,7 +184,7 @@ layout: none
         padding: 2.25rem;
       }
 
-      h1 {
+      .case-title {
         font-size: 2.1rem;
       }
 
@@ -256,38 +215,7 @@ layout: none
 <body>
   {% include landmark-nav.html %}
   <main class="study-page case-prep">
-    <header class="study-header">
-      {% if page.exam_focus %}
-        <div class="study-eyebrow">{{ page.exam_focus }}</div>
-      {% endif %}
-      <h1>{{ page.title }}</h1>
-      <div class="meta-grid">
-        {% if page.difficulty %}
-          <div class="meta-card">
-            <h3>Complexity</h3>
-            <p>{{ page.difficulty }}</p>
-          </div>
-        {% endif %}
-        {% if page.time_goal %}
-          <div class="meta-card">
-            <h3>Time Goal</h3>
-            <p>{{ page.time_goal }}</p>
-          </div>
-        {% endif %}
-        {% if page.attending_notes %}
-          <div class="meta-card">
-            <h3>Attending Notes</h3>
-            <p>{{ page.attending_notes }}</p>
-          </div>
-        {% endif %}
-        {% if page.patient_profile %}
-          <div class="meta-card">
-            <h3>Patient Snapshot</h3>
-            <p>{{ page.patient_profile }}</p>
-          </div>
-        {% endif %}
-      </div>
-    </header>
+    <h1 class="case-title">{{ page.title }}</h1>
 
     {% if page.high_yield_pearls %}
       <section class="high-yield-pearls">

--- a/_layouts/landmark.html
+++ b/_layouts/landmark.html
@@ -133,13 +133,6 @@ layout: none
       margin-bottom: 0.5rem;
     }
 
-    .page-subtitle {
-      font-size: 1rem;
-      color: var(--muted);
-      margin-bottom: 2rem;
-      font-style: italic;
-    }
-
     h2 {
       margin-top: 2.5rem;
       font-size: 1.5rem;
@@ -310,9 +303,6 @@ layout: none
       {% unless page.hide_page_title %}
         <h1>{{ page.title }}</h1>
       {% endunless %}
-      {% if page.subtitle and page.hide_page_subtitle != true %}
-        <p class="page-subtitle">{{ page.subtitle }}</p>
-      {% endif %}
       {{ content }}
     </div>
 

--- a/_layouts/topic-review.html
+++ b/_layouts/topic-review.html
@@ -255,9 +255,6 @@ layout: none
         <div class="study-eyebrow">{{ page.exam_focus }}</div>
       {% endif %}
       <h1>{{ page.title }}</h1>
-      {% if page.subtitle %}
-        <p class="page-subtitle">{{ page.subtitle }}</p>
-      {% endif %}
       <div class="meta-grid">
         {% if page.difficulty %}
           <div class="meta-card">


### PR DESCRIPTION
## Summary
- remove the case prep hero meta grid so pages open directly on the high-yield pearls content
- stop rendering page subtitles in the shared header, topic review, and landmark layouts so duplicate headings no longer appear

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Bundler 403 Forbidden error)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ee5fe7f8832697bf1c7158096f01