### PR TITLE
Make Landmark paper review TOC sticky on desktop

### DIFF
--- a/_layouts/landmark.html
+++ b/_layouts/landmark.html
@@ -218,6 +218,10 @@ layout: none
         border-radius: 6px;
         box-shadow: 0 2px 6px rgba(0,0,0,0.05);
         align-self: flex-start;
+        position: sticky;
+        top: 6.5rem;
+        max-height: calc(100vh - 7rem);
+        overflow-y: auto;
       }
 
       .toc-box.is-visible {


### PR DESCRIPTION
## Summary
- keep the paper review table of contents visible on desktop by making it sticky within the Landmark layout
- constrain the table of contents height and allow internal scrolling so it remains usable while fixed

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e303f355b883269f5354a286682f68