### PR TITLE
Make topic review layout mobile friendly

### DIFF
--- a/_includes/landmark-nav.html
+++ b/_includes/landmark-nav.html
@@ -1,9 +1,13 @@
-<header>
+<header class="landmark-nav">
   <a class="brand" href="/landmark">
     <img src="/assets/img/NKR_white.png" alt="NKR logo">
     <span class="brand-text">Surgery Study Hub</span>
   </a>
-  <nav class="nav-actions" aria-label="Primary navigation">
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="landmark-nav-actions">
+    Menu
+    <span class="nav-toggle-icon" aria-hidden="true">☰</span>
+  </button>
+  <nav id="landmark-nav-actions" class="nav-actions" aria-label="Primary navigation">
     <a class="nav-button" href="/landmark/paper-review/">Papers</a>
     <a class="nav-button" href="/landmark/topic-review/">Topics</a>
     <a class="nav-button" href="/landmark/case-prep/">Surgeries</a>

--- a/_layouts/topic-review.html
+++ b/_layouts/topic-review.html
@@ -43,7 +43,7 @@ layout: none
       text-decoration: underline;
     }
 
-    header {
+    .landmark-nav {
       background: var(--navy);
       color: white;
       padding: 1.25rem 2rem;
@@ -86,6 +86,37 @@ layout: none
       font-family: 'Manrope', sans-serif;
     }
 
+    .nav-toggle {
+      display: none;
+      margin-left: auto;
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: 999px;
+      padding: 0.45rem 1rem;
+      font-family: 'Manrope', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+    }
+
+    .nav-toggle:focus-visible {
+      outline: 3px solid var(--aqua);
+      outline-offset: 2px;
+    }
+
+    .nav-toggle-icon {
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+
+    .nav-actions.is-open {
+      display: flex;
+    }
+
     .nav-button {
       background: white;
       color: var(--navy);
@@ -123,6 +154,12 @@ layout: none
       flex-direction: column;
       gap: 0.5rem;
       margin-bottom: 2rem;
+      background: var(--navy);
+      color: white;
+      padding: 2rem;
+      border-radius: 18px;
+      position: static;
+      box-shadow: 0 8px 18px rgba(12, 44, 71, 0.18);
     }
 
     .study-eyebrow {
@@ -130,7 +167,7 @@ layout: none
       font-size: 0.95rem;
       text-transform: uppercase;
       letter-spacing: 0.1rem;
-      color: var(--muted);
+      color: rgba(255, 255, 255, 0.7);
     }
 
     h1 {
@@ -138,6 +175,10 @@ layout: none
       font-size: 2.4rem;
       margin: 0;
       color: var(--navy);
+    }
+
+    .study-header h1 {
+      color: #f5f7fa;
     }
 
     .meta-grid {
@@ -223,26 +264,42 @@ layout: none
         font-size: 2rem;
       }
 
-      header {
-        flex-direction: column;
-        align-items: flex-start;
+      .landmark-nav {
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      .nav-toggle {
+        display: inline-flex;
       }
 
       .nav-actions {
+        display: none;
         width: 100%;
-        justify-content: flex-start;
+        flex-direction: column;
+        align-items: stretch;
         gap: 0.75rem;
-      }
-    }
-
-    @media (max-width: 600px) {
-      .nav-actions {
-        gap: 0.6rem;
+        margin-left: 0;
       }
 
       .nav-button {
         width: 100%;
         justify-content: center;
+      }
+
+      .study-header {
+        display: none;
+      }
+    }
+
+    @media (max-width: 600px) {
+      main {
+        margin: 1.5rem 0.75rem;
+        padding: 1.75rem;
+      }
+
+      .nav-actions {
+        gap: 0.6rem;
       }
     }
   </style>
@@ -356,5 +413,21 @@ layout: none
       </section>
     {% endif %}
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var toggle = document.querySelector('.nav-toggle');
+      var actions = document.getElementById('landmark-nav-actions');
+
+      if (!toggle || !actions) {
+        return;
+      }
+
+      toggle.addEventListener('click', function () {
+        var isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!isExpanded));
+        actions.classList.toggle('is-open');
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a collapsible menu toggle to the landmark navigation include for narrow screens
- hide the topic review hero block on mobile and tighten mobile spacing
- add a lightweight script to drive the mobile navigation toggle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e303546674832687518a90ae325423