### PR TITLE
Improve Landmark mobile navigation and topic header

### DIFF
--- a/_layouts/case-prep.html
+++ b/_layouts/case-prep.html
@@ -86,6 +86,37 @@ layout: none
       font-family: 'Manrope', sans-serif;
     }
 
+    .nav-toggle {
+      display: none;
+      margin-left: auto;
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: 999px;
+      padding: 0.45rem 1rem;
+      font-family: 'Manrope', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+    }
+
+    .nav-toggle:focus-visible {
+      outline: 3px solid var(--aqua);
+      outline-offset: 2px;
+    }
+
+    .nav-toggle-icon {
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+
+    .nav-actions.is-open {
+      display: flex;
+    }
+
     .nav-button {
       background: white;
       color: var(--navy);
@@ -189,25 +220,35 @@ layout: none
       }
 
       header {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .nav-toggle {
+        display: inline-flex;
       }
 
       .nav-actions {
+        display: none;
         width: 100%;
-        justify-content: flex-start;
+        flex-direction: column;
+        align-items: center;
         gap: 0.75rem;
+        margin-left: 0;
+      }
+
+      .nav-button {
+        width: 100%;
+        max-width: 320px;
+        justify-content: center;
+        margin: 0 auto;
       }
     }
 
     @media (max-width: 600px) {
       .nav-actions {
         gap: 0.6rem;
-      }
-
-      .nav-button {
-        width: 100%;
-        justify-content: center;
       }
     }
   </style>
@@ -307,5 +348,21 @@ layout: none
       </section>
     {% endif %}
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var toggle = document.querySelector('.nav-toggle');
+      var actions = document.getElementById('landmark-nav-actions');
+
+      if (!toggle || !actions) {
+        return;
+      }
+
+      toggle.addEventListener('click', function () {
+        var isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!isExpanded));
+        actions.classList.toggle('is-open');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/_layouts/landmark.html
+++ b/_layouts/landmark.html
@@ -90,6 +90,37 @@ layout: none
       font-family: 'Manrope', sans-serif;
     }
 
+    .nav-toggle {
+      display: none;
+      margin-left: auto;
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: 999px;
+      padding: 0.45rem 1rem;
+      font-family: 'Manrope', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+    }
+
+    .nav-toggle:focus-visible {
+      outline: 3px solid var(--aqua);
+      outline-offset: 2px;
+    }
+
+    .nav-toggle-icon {
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+
+    .nav-actions.is-open {
+      display: flex;
+    }
+
     .nav-button {
       background: white;
       color: var(--navy);
@@ -268,24 +299,34 @@ layout: none
       }
 
       header {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .nav-toggle {
+        display: inline-flex;
       }
 
       .nav-actions {
+        display: none;
         width: 100%;
-        justify-content: flex-start;
+        flex-direction: column;
+        align-items: center;
         gap: 0.75rem;
+        margin-left: 0;
+      }
+
+      .nav-button {
+        width: 100%;
+        max-width: 320px;
+        justify-content: center;
+        margin: 0 auto;
       }
     }
     @media (max-width: 600px) {
       .nav-actions {
         gap: 0.6rem;
-      }
-
-      .nav-button {
-        width: 100%;
-        justify-content: center;
       }
     }
   </style>
@@ -316,6 +357,23 @@ layout: none
     </nav>
     {% endif %}
   </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var toggle = document.querySelector('.nav-toggle');
+      var actions = document.getElementById('landmark-nav-actions');
+
+      if (!toggle || !actions) {
+        return;
+      }
+
+      toggle.addEventListener('click', function () {
+        var isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!isExpanded));
+        actions.classList.toggle('is-open');
+      });
+    });
+  </script>
 
   {% if show_toc %}
   <!-- TOC JS -->

--- a/_layouts/topic-review.html
+++ b/_layouts/topic-review.html
@@ -160,6 +160,8 @@ layout: none
       border-radius: 18px;
       position: static;
       box-shadow: 0 8px 18px rgba(12, 44, 71, 0.18);
+      align-items: center;
+      text-align: center;
     }
 
     .study-eyebrow {
@@ -186,6 +188,8 @@ layout: none
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 1rem;
       margin-top: 1.5rem;
+      justify-items: center;
+      width: 100%;
     }
 
     .meta-card {
@@ -193,6 +197,7 @@ layout: none
       border-radius: 14px;
       padding: 1rem 1.25rem;
       font-family: 'Manrope', sans-serif;
+      text-align: center;
     }
 
     .meta-card h3 {
@@ -277,14 +282,16 @@ layout: none
         display: none;
         width: 100%;
         flex-direction: column;
-        align-items: stretch;
+        align-items: center;
         gap: 0.75rem;
         margin-left: 0;
       }
 
       .nav-button {
         width: 100%;
+        max-width: 320px;
         justify-content: center;
+        margin: 0 auto;
       }
 
       .study-header {


### PR DESCRIPTION
## Summary
- ensure the Landmark navigation collapses behind a mobile toggle and centers revealed buttons across layouts
- add shared toggle scripting to Landmark layouts so the dropdown opens and closes consistently
- center the Topic Review banner title and metadata for improved presentation

## Testing
- `bundle install` *(fails: unable to download gems due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e309371358832698a72541f2ec01ff